### PR TITLE
Enable execution JUnit5 tests

### DIFF
--- a/stable/original/junit.extensions.eclipse.quick/src/junit/extensions/eclipse/quick/JavaElements.java
+++ b/stable/original/junit.extensions.eclipse.quick/src/junit/extensions/eclipse/quick/JavaElements.java
@@ -17,7 +17,7 @@ public class JavaElements {
         if (!method.getReturnType().equals("V"))
             return false;
         final int flags = method.getFlags();
-        if (!Flags.isPublic(flags) || Flags.isStatic(flags))
+        if (Flags.isPrivate(flags) || Flags.isStatic(flags))
             return false;
         if (method.getElementName().startsWith("test"))
             return true;

--- a/stable/original/junit.extensions.eclipse.quick/src/junit/extensions/eclipse/quick/JavaElements.java
+++ b/stable/original/junit.extensions.eclipse.quick/src/junit/extensions/eclipse/quick/JavaElements.java
@@ -96,7 +96,7 @@ public class JavaElements {
         if (!type.isClass())
             return false;
         final int flags = type.getFlags();
-        if (Flags.isAbstract(flags) || !Flags.isPublic(flags))
+        if (Flags.isAbstract(flags) || Flags.isPrivate(flags))
             return false;
 
         return true;


### PR DESCRIPTION
closes #3 
`protected`, `package private` なメソッド、クラスをテスト対象から除外しない(除外するのは `private`  
のみに変更)